### PR TITLE
Auto-run migrations on first docker compose up

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -1,0 +1,5 @@
+# TODO
+
+## Future improvements
+
+- [ ] Add golang-migrate for production migrations (when needed for incremental migrations on existing databases)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       - "${POSTGRES_PORT:-5432}:5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
+      - ./sql/migrations:/docker-entrypoint-initdb.d:ro
     restart: unless-stopped
 
   pgadmin:


### PR DESCRIPTION
## Summary
- Mount `sql/migrations` to `/docker-entrypoint-initdb.d/` for automatic migration execution
- Add `TODO.md` with future improvement notes

## Result
New developers can now:
```bash
git clone <repo>
docker compose up -d
```
And have a fully initialized database with all tables.

Closes #5