### PR TITLE
Auto-configure pgAdmin and add documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,102 @@
+# NDP Affinities
+
+PostgreSQL database for the NDP Affinities system.
+
+## Requirements
+
+- Docker
+- Docker Compose
+
+## Quick Start
+
+```bash
+docker compose up -d
+```
+
+This will start:
+- **PostgreSQL** on `localhost:5432`
+- **pgAdmin** on `http://localhost:5050`
+
+Migrations run automatically on first startup.
+
+## Environment Variables
+
+Copy `.env.example` to `.env` to customize:
+
+```bash
+cp .env.example .env
+```
+
+### PostgreSQL
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `POSTGRES_USER` | `affinities` | Database user |
+| `POSTGRES_PASSWORD` | `affinities` | Database password |
+| `POSTGRES_DB` | `affinities` | Database name |
+| `POSTGRES_PORT` | `5432` | Exposed port |
+
+### pgAdmin
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `PGADMIN_EMAIL` | `admin@admin.com` | Login email |
+| `PGADMIN_PASSWORD` | `admin` | Login password |
+| `PGADMIN_PORT` | `5050` | Exposed port |
+
+## Accessing pgAdmin
+
+1. Open http://localhost:5050
+2. Login with `admin@admin.com` / `admin` (or your `.env` values)
+3. The server "affinities" is pre-configured
+4. Enter the database password when prompted: `affinities` (or your `.env` value)
+
+> **Note:** If you change `POSTGRES_USER`, `POSTGRES_DB`, or `POSTGRES_PASSWORD` in `.env`, you must also update `pgadmin/servers.json` to match.
+
+## Commands
+
+```bash
+# Start services
+docker compose up -d
+
+# Stop services
+docker compose down
+
+# Stop and remove volumes (deletes all data)
+docker compose down -v
+
+# View logs
+docker compose logs -f
+
+# Connect to PostgreSQL directly
+docker exec -it ndp-affinities-db psql -U affinities -d affinities
+```
+
+## Database Schema
+
+### ndp_endpoint
+
+Stores endpoint information.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `uid` | UUID | PK, auto-generated |
+| `kind` | TEXT | NOT NULL |
+| `url` | TEXT | |
+| `source_ep` | TEXT | |
+| `metadata` | JSONB | |
+| `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
+| `updated_at` | TIMESTAMPTZ | NOT NULL, auto-updated on modify |
+
+## Project Structure
+
+```
+.
+├── docker-compose.yml
+├── .env.example
+├── pgadmin/
+│   └── servers.json      # pgAdmin server configuration
+└── sql/
+    └── migrations/       # Database migrations (run automatically)
+        └── 001_create_ndp_endpoint.sql
+```

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,6 +23,7 @@ services:
       - "${PGADMIN_PORT:-5050}:80"
     volumes:
       - pgadmin_data:/var/lib/pgadmin
+      - ./pgadmin/servers.json:/pgadmin4/servers.json:ro
     depends_on:
       - postgres
     restart: unless-stopped

--- a/pgadmin/servers.json
+++ b/pgadmin/servers.json
@@ -1,0 +1,13 @@
+{
+  "Servers": {
+    "1": {
+      "Name": "affinities",
+      "Group": "Servers",
+      "Host": "postgres",
+      "Port": 5432,
+      "MaintenanceDB": "affinities",
+      "Username": "affinities",
+      "SSLMode": "prefer"
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add `pgadmin/servers.json` for automatic server configuration
- Add `README.md` with full documentation:
  - Quick start guide
  - Environment variables
  - pgAdmin access instructions
  - Database schema
  - Project structure

## Result
- pgAdmin shows pre-configured server on startup
- New developers have complete setup documentation

Closes #7