### PR TITLE
Add ndp_dataset table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,19 @@ Stores endpoint information.
 | `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
 | `updated_at` | TIMESTAMPTZ | NOT NULL, auto-updated on modify |
 
+### ndp_dataset
+
+Stores dataset information.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `uid` | UUID | PK, auto-generated |
+| `title` | TEXT | |
+| `source_ep` | TEXT | |
+| `metadata` | JSONB | |
+| `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
+| `updated_at` | TIMESTAMPTZ | NOT NULL, auto-updated on modify |
+
 ## Project Structure
 
 ```
@@ -98,5 +111,6 @@ Stores endpoint information.
 │   └── servers.json      # pgAdmin server configuration
 └── sql/
     └── migrations/       # Database migrations (run automatically)
-        └── 001_create_ndp_endpoint.sql
+        ├── 001_create_ndp_endpoint.sql
+        └── 002_create_ndp_dataset.sql
 ```

--- a/sql/migrations/002_create_ndp_dataset.sql
+++ b/sql/migrations/002_create_ndp_dataset.sql
@@ -1,0 +1,15 @@
+-- Create ndp_dataset table
+CREATE TABLE ndp_dataset (
+    uid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    title TEXT,
+    source_ep TEXT,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Trigger for ndp_dataset
+CREATE TRIGGER trg_ndp_dataset_updated_at
+    BEFORE UPDATE ON ndp_dataset
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- Create `ndp_dataset` table with UUID primary key
- Add trigger for auto-updating `updated_at`
- Update README with table schema

## Schema
| Column | Type | Constraints |
|--------|------|-------------|
| uid | UUID | PK, auto-generated |
| title | TEXT | |
| source_ep | TEXT | |
| metadata | JSONB | |
| created_at | TIMESTAMPTZ | NOT NULL, DEFAULT NOW() |
| updated_at | TIMESTAMPTZ | NOT NULL, auto-updates |

Closes #9