### PR TITLE
Add ndp_service table migration

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,6 +101,21 @@ Stores dataset information.
 | `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
 | `updated_at` | TIMESTAMPTZ | NOT NULL, auto-updated on modify |
 
+### ndp_service
+
+Stores service information.
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `uid` | UUID | PK, auto-generated |
+| `type` | TEXT | |
+| `openapi_url` | TEXT | |
+| `version` | TEXT | |
+| `source_ep` | TEXT | |
+| `metadata` | JSONB | |
+| `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
+| `updated_at` | TIMESTAMPTZ | NOT NULL, auto-updated on modify |
+
 ## Project Structure
 
 ```
@@ -112,5 +127,6 @@ Stores dataset information.
 └── sql/
     └── migrations/       # Database migrations (run automatically)
         ├── 001_create_ndp_endpoint.sql
-        └── 002_create_ndp_dataset.sql
+        ├── 002_create_ndp_dataset.sql
+        └── 003_create_ndp_service.sql
 ```

--- a/sql/migrations/003_create_ndp_service.sql
+++ b/sql/migrations/003_create_ndp_service.sql
@@ -1,0 +1,17 @@
+-- Create ndp_service table
+CREATE TABLE ndp_service (
+    uid UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    type TEXT,
+    openapi_url TEXT,
+    version TEXT,
+    source_ep TEXT,
+    metadata JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Trigger for ndp_service
+CREATE TRIGGER trg_ndp_service_updated_at
+    BEFORE UPDATE ON ndp_service
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at_column();


### PR DESCRIPTION
## Summary
- Create `ndp_service` table with UUID primary key
- Add trigger for auto-updating `updated_at`
- Update README with table schema

Closes #11