### PR TITLE
Add ndp_dataset_endpoint junction table

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ Stores service information.
 | `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
 | `updated_at` | TIMESTAMPTZ | NOT NULL, auto-updated on modify |
 
+### ndp_dataset_endpoint
+
+Junction table connecting datasets with endpoints (many-to-many).
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `dataset_uid` | UUID | PK, FK → ndp_dataset |
+| `endpoint_uid` | UUID | PK, FK → ndp_endpoint |
+| `role` | TEXT | |
+| `attrs` | JSONB | |
+| `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
+
 ## Project Structure
 
 ```
@@ -128,5 +140,6 @@ Stores service information.
     └── migrations/       # Database migrations (run automatically)
         ├── 001_create_ndp_endpoint.sql
         ├── 002_create_ndp_dataset.sql
-        └── 003_create_ndp_service.sql
+        ├── 003_create_ndp_service.sql
+        └── 004_create_ndp_dataset_endpoint.sql
 ```

--- a/sql/migrations/004_create_ndp_dataset_endpoint.sql
+++ b/sql/migrations/004_create_ndp_dataset_endpoint.sql
@@ -1,0 +1,13 @@
+-- Create ndp_dataset_endpoint junction table
+CREATE TABLE ndp_dataset_endpoint (
+    dataset_uid UUID NOT NULL REFERENCES ndp_dataset(uid) ON DELETE CASCADE,
+    endpoint_uid UUID NOT NULL REFERENCES ndp_endpoint(uid) ON DELETE CASCADE,
+    role TEXT,
+    attrs JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (dataset_uid, endpoint_uid)
+);
+
+-- Indexes for FK columns (improve JOIN performance)
+CREATE INDEX idx_ndp_dataset_endpoint_dataset ON ndp_dataset_endpoint(dataset_uid);
+CREATE INDEX idx_ndp_dataset_endpoint_endpoint ON ndp_dataset_endpoint(endpoint_uid);


### PR DESCRIPTION
## Summary
- Create `ndp_dataset_endpoint` junction table
- Add composite primary key (dataset_uid, endpoint_uid)
- Add FK constraints with ON DELETE CASCADE
- Add indexes for FK columns

Closes #13