### PR TITLE
Add ndp_dataset_service junction table

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,18 @@ Junction table connecting datasets with endpoints (many-to-many).
 | `attrs` | JSONB | |
 | `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
 
+### ndp_dataset_service
+
+Junction table connecting datasets with services (many-to-many).
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `dataset_uid` | UUID | PK, FK → ndp_dataset |
+| `service_uid` | UUID | PK, FK → ndp_service |
+| `role` | TEXT | |
+| `attrs` | JSONB | |
+| `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
+
 ## Project Structure
 
 ```
@@ -141,5 +153,6 @@ Junction table connecting datasets with endpoints (many-to-many).
         ├── 001_create_ndp_endpoint.sql
         ├── 002_create_ndp_dataset.sql
         ├── 003_create_ndp_service.sql
-        └── 004_create_ndp_dataset_endpoint.sql
+        ├── 004_create_ndp_dataset_endpoint.sql
+        └── 005_create_ndp_dataset_service.sql
 ```

--- a/sql/migrations/005_create_ndp_dataset_service.sql
+++ b/sql/migrations/005_create_ndp_dataset_service.sql
@@ -1,0 +1,13 @@
+-- Create ndp_dataset_service junction table
+CREATE TABLE ndp_dataset_service (
+    dataset_uid UUID NOT NULL REFERENCES ndp_dataset(uid) ON DELETE CASCADE,
+    service_uid UUID NOT NULL REFERENCES ndp_service(uid) ON DELETE CASCADE,
+    role TEXT,
+    attrs JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (dataset_uid, service_uid)
+);
+
+-- Indexes for FK columns
+CREATE INDEX idx_ndp_dataset_service_dataset ON ndp_dataset_service(dataset_uid);
+CREATE INDEX idx_ndp_dataset_service_service ON ndp_dataset_service(service_uid);


### PR DESCRIPTION
## Summary
- Create `ndp_dataset_service` junction table
- Add composite primary key (dataset_uid, service_uid)
- Add FK constraints with ON DELETE CASCADE
- Add indexes for FK columns

Closes #15