### PR TITLE
Add ndp_service_endpoint junction table

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,6 +140,18 @@ Junction table connecting datasets with services (many-to-many).
 | `attrs` | JSONB | |
 | `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
 
+### ndp_service_endpoint
+
+Junction table connecting services with endpoints (many-to-many).
+
+| Column | Type | Constraints |
+|--------|------|-------------|
+| `service_uid` | UUID | PK, FK → ndp_service |
+| `endpoint_uid` | UUID | PK, FK → ndp_endpoint |
+| `role` | TEXT | |
+| `attrs` | JSONB | |
+| `created_at` | TIMESTAMPTZ | NOT NULL, auto-generated |
+
 ## Project Structure
 
 ```
@@ -154,5 +166,6 @@ Junction table connecting datasets with services (many-to-many).
         ├── 002_create_ndp_dataset.sql
         ├── 003_create_ndp_service.sql
         ├── 004_create_ndp_dataset_endpoint.sql
-        └── 005_create_ndp_dataset_service.sql
+        ├── 005_create_ndp_dataset_service.sql
+        └── 006_create_ndp_service_endpoint.sql
 ```

--- a/sql/migrations/006_create_ndp_service_endpoint.sql
+++ b/sql/migrations/006_create_ndp_service_endpoint.sql
@@ -1,0 +1,13 @@
+-- Create ndp_service_endpoint junction table
+CREATE TABLE ndp_service_endpoint (
+    service_uid UUID NOT NULL REFERENCES ndp_service(uid) ON DELETE CASCADE,
+    endpoint_uid UUID NOT NULL REFERENCES ndp_endpoint(uid) ON DELETE CASCADE,
+    role TEXT,
+    attrs JSONB,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    PRIMARY KEY (service_uid, endpoint_uid)
+);
+
+-- Indexes for FK columns
+CREATE INDEX idx_ndp_service_endpoint_service ON ndp_service_endpoint(service_uid);
+CREATE INDEX idx_ndp_service_endpoint_endpoint ON ndp_service_endpoint(endpoint_uid);


### PR DESCRIPTION
## Summary
- Create `ndp_service_endpoint` junction table
- Add composite primary key (service_uid, endpoint_uid)
- Add FK constraints with ON DELETE CASCADE
- Add indexes for FK columns

Closes #17