### PR TITLE
Add CRUD for all remaining tables

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -1,6 +1,14 @@
 from fastapi import FastAPI
 
-from app.routers import endpoints_router
+from app.routers import (
+    endpoints_router,
+    datasets_router,
+    services_router,
+    dataset_endpoints_router,
+    dataset_services_router,
+    service_endpoints_router,
+    affinities_router,
+)
 
 app = FastAPI(
     title="NDP Affinities API",
@@ -9,6 +17,12 @@ app = FastAPI(
 )
 
 app.include_router(endpoints_router)
+app.include_router(datasets_router)
+app.include_router(services_router)
+app.include_router(dataset_endpoints_router)
+app.include_router(dataset_services_router)
+app.include_router(service_endpoints_router)
+app.include_router(affinities_router)
 
 
 @app.get("/health")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,3 +1,17 @@
 from app.models.endpoint import Endpoint
+from app.models.dataset import Dataset
+from app.models.service import Service
+from app.models.dataset_endpoint import DatasetEndpoint
+from app.models.dataset_service import DatasetService
+from app.models.service_endpoint import ServiceEndpoint
+from app.models.affinity_triple import AffinityTriple
 
-__all__ = ["Endpoint"]
+__all__ = [
+    "Endpoint",
+    "Dataset",
+    "Service",
+    "DatasetEndpoint",
+    "DatasetService",
+    "ServiceEndpoint",
+    "AffinityTriple",
+]

--- a/app/models/affinity_triple.py
+++ b/app/models/affinity_triple.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, Integer, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, JSONB, ARRAY
+
+from app.database import Base
+
+
+class AffinityTriple(Base):
+    __tablename__ = "ndp_affinity_triple"
+
+    triple_uid = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    dataset_uid = Column(UUID(as_uuid=True), ForeignKey("ndp_dataset.uid", ondelete="CASCADE"), nullable=True)
+    endpoint_uids = Column(ARRAY(UUID(as_uuid=True)), nullable=True)
+    service_uids = Column(ARRAY(UUID(as_uuid=True)), nullable=True)
+    attrs = Column(JSONB, nullable=True)
+    version = Column(Integer, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)

--- a/app/models/dataset.py
+++ b/app/models/dataset.py
@@ -1,0 +1,18 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, String, DateTime
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from app.database import Base
+
+
+class Dataset(Base):
+    __tablename__ = "ndp_dataset"
+
+    uid = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    title = Column(String, nullable=True)
+    source_ep = Column(String, nullable=True)
+    metadata_ = Column("metadata", JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)

--- a/app/models/dataset_endpoint.py
+++ b/app/models/dataset_endpoint.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from app.database import Base
+
+
+class DatasetEndpoint(Base):
+    __tablename__ = "ndp_dataset_endpoint"
+
+    dataset_uid = Column(UUID(as_uuid=True), ForeignKey("ndp_dataset.uid", ondelete="CASCADE"), primary_key=True)
+    endpoint_uid = Column(UUID(as_uuid=True), ForeignKey("ndp_endpoint.uid", ondelete="CASCADE"), primary_key=True)
+    role = Column(String, nullable=True)
+    attrs = Column(JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)

--- a/app/models/dataset_service.py
+++ b/app/models/dataset_service.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from app.database import Base
+
+
+class DatasetService(Base):
+    __tablename__ = "ndp_dataset_service"
+
+    dataset_uid = Column(UUID(as_uuid=True), ForeignKey("ndp_dataset.uid", ondelete="CASCADE"), primary_key=True)
+    service_uid = Column(UUID(as_uuid=True), ForeignKey("ndp_service.uid", ondelete="CASCADE"), primary_key=True)
+    role = Column(String, nullable=True)
+    attrs = Column(JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -1,0 +1,20 @@
+import uuid
+from datetime import datetime
+
+from sqlalchemy import Column, String, DateTime
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from app.database import Base
+
+
+class Service(Base):
+    __tablename__ = "ndp_service"
+
+    uid = Column(UUID(as_uuid=True), primary_key=True, default=uuid.uuid4)
+    type = Column(String, nullable=True)
+    openapi_url = Column(String, nullable=True)
+    version = Column(String, nullable=True)
+    source_ep = Column(String, nullable=True)
+    metadata_ = Column("metadata", JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)

--- a/app/models/service_endpoint.py
+++ b/app/models/service_endpoint.py
@@ -1,0 +1,16 @@
+from datetime import datetime
+
+from sqlalchemy import Column, String, DateTime, ForeignKey
+from sqlalchemy.dialects.postgresql import UUID, JSONB
+
+from app.database import Base
+
+
+class ServiceEndpoint(Base):
+    __tablename__ = "ndp_service_endpoint"
+
+    service_uid = Column(UUID(as_uuid=True), ForeignKey("ndp_service.uid", ondelete="CASCADE"), primary_key=True)
+    endpoint_uid = Column(UUID(as_uuid=True), ForeignKey("ndp_endpoint.uid", ondelete="CASCADE"), primary_key=True)
+    role = Column(String, nullable=True)
+    attrs = Column(JSONB, nullable=True)
+    created_at = Column(DateTime(timezone=True), nullable=False, default=datetime.utcnow)

--- a/app/routers/__init__.py
+++ b/app/routers/__init__.py
@@ -1,3 +1,17 @@
 from app.routers.endpoints import router as endpoints_router
+from app.routers.datasets import router as datasets_router
+from app.routers.services import router as services_router
+from app.routers.dataset_endpoints import router as dataset_endpoints_router
+from app.routers.dataset_services import router as dataset_services_router
+from app.routers.service_endpoints import router as service_endpoints_router
+from app.routers.affinities import router as affinities_router
 
-__all__ = ["endpoints_router"]
+__all__ = [
+    "endpoints_router",
+    "datasets_router",
+    "services_router",
+    "dataset_endpoints_router",
+    "dataset_services_router",
+    "service_endpoints_router",
+    "affinities_router",
+]

--- a/app/routers/affinities.py
+++ b/app/routers/affinities.py
@@ -1,0 +1,62 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.affinity_triple import AffinityTriple
+from app.schemas.affinity_triple import AffinityTripleCreate, AffinityTripleUpdate, AffinityTripleResponse
+
+router = APIRouter(prefix="/affinities", tags=["affinities"])
+
+
+@router.get("", response_model=list[AffinityTripleResponse])
+def list_affinities(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(AffinityTriple).offset(skip).limit(limit).all()
+
+
+@router.get("/{triple_uid}", response_model=AffinityTripleResponse)
+def get_affinity(triple_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(AffinityTriple).filter(AffinityTriple.triple_uid == triple_uid).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="AffinityTriple not found")
+    return item
+
+
+@router.post("", response_model=AffinityTripleResponse, status_code=201)
+def create_affinity(data: AffinityTripleCreate, db: Session = Depends(get_db)):
+    item = AffinityTriple(
+        dataset_uid=data.dataset_uid,
+        endpoint_uids=data.endpoint_uids,
+        service_uids=data.service_uids,
+        attrs=data.attrs,
+        version=data.version,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.put("/{triple_uid}", response_model=AffinityTripleResponse)
+def update_affinity(triple_uid: UUID, data: AffinityTripleUpdate, db: Session = Depends(get_db)):
+    item = db.query(AffinityTriple).filter(AffinityTriple.triple_uid == triple_uid).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="AffinityTriple not found")
+
+    update_data = data.model_dump(exclude_unset=True)
+    for field, value in update_data.items():
+        setattr(item, field, value)
+
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/{triple_uid}", status_code=204)
+def delete_affinity(triple_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(AffinityTriple).filter(AffinityTriple.triple_uid == triple_uid).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="AffinityTriple not found")
+    db.delete(item)
+    db.commit()

--- a/app/routers/dataset_endpoints.py
+++ b/app/routers/dataset_endpoints.py
@@ -1,0 +1,52 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.dataset_endpoint import DatasetEndpoint
+from app.schemas.dataset_endpoint import DatasetEndpointCreate, DatasetEndpointResponse
+
+router = APIRouter(prefix="/dataset-endpoints", tags=["dataset-endpoints"])
+
+
+@router.get("", response_model=list[DatasetEndpointResponse])
+def list_dataset_endpoints(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(DatasetEndpoint).offset(skip).limit(limit).all()
+
+
+@router.get("/{dataset_uid}/{endpoint_uid}", response_model=DatasetEndpointResponse)
+def get_dataset_endpoint(dataset_uid: UUID, endpoint_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(DatasetEndpoint).filter(
+        DatasetEndpoint.dataset_uid == dataset_uid,
+        DatasetEndpoint.endpoint_uid == endpoint_uid
+    ).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="DatasetEndpoint not found")
+    return item
+
+
+@router.post("", response_model=DatasetEndpointResponse, status_code=201)
+def create_dataset_endpoint(data: DatasetEndpointCreate, db: Session = Depends(get_db)):
+    item = DatasetEndpoint(
+        dataset_uid=data.dataset_uid,
+        endpoint_uid=data.endpoint_uid,
+        role=data.role,
+        attrs=data.attrs,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/{dataset_uid}/{endpoint_uid}", status_code=204)
+def delete_dataset_endpoint(dataset_uid: UUID, endpoint_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(DatasetEndpoint).filter(
+        DatasetEndpoint.dataset_uid == dataset_uid,
+        DatasetEndpoint.endpoint_uid == endpoint_uid
+    ).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="DatasetEndpoint not found")
+    db.delete(item)
+    db.commit()

--- a/app/routers/dataset_services.py
+++ b/app/routers/dataset_services.py
@@ -1,0 +1,52 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.dataset_service import DatasetService
+from app.schemas.dataset_service import DatasetServiceCreate, DatasetServiceResponse
+
+router = APIRouter(prefix="/dataset-services", tags=["dataset-services"])
+
+
+@router.get("", response_model=list[DatasetServiceResponse])
+def list_dataset_services(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(DatasetService).offset(skip).limit(limit).all()
+
+
+@router.get("/{dataset_uid}/{service_uid}", response_model=DatasetServiceResponse)
+def get_dataset_service(dataset_uid: UUID, service_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(DatasetService).filter(
+        DatasetService.dataset_uid == dataset_uid,
+        DatasetService.service_uid == service_uid
+    ).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="DatasetService not found")
+    return item
+
+
+@router.post("", response_model=DatasetServiceResponse, status_code=201)
+def create_dataset_service(data: DatasetServiceCreate, db: Session = Depends(get_db)):
+    item = DatasetService(
+        dataset_uid=data.dataset_uid,
+        service_uid=data.service_uid,
+        role=data.role,
+        attrs=data.attrs,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/{dataset_uid}/{service_uid}", status_code=204)
+def delete_dataset_service(dataset_uid: UUID, service_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(DatasetService).filter(
+        DatasetService.dataset_uid == dataset_uid,
+        DatasetService.service_uid == service_uid
+    ).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="DatasetService not found")
+    db.delete(item)
+    db.commit()

--- a/app/routers/datasets.py
+++ b/app/routers/datasets.py
@@ -1,0 +1,63 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.dataset import Dataset
+from app.schemas.dataset import DatasetCreate, DatasetUpdate, DatasetResponse
+
+router = APIRouter(prefix="/datasets", tags=["datasets"])
+
+
+@router.get("", response_model=list[DatasetResponse])
+def list_datasets(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(Dataset).offset(skip).limit(limit).all()
+
+
+@router.get("/{uid}", response_model=DatasetResponse)
+def get_dataset(uid: UUID, db: Session = Depends(get_db)):
+    dataset = db.query(Dataset).filter(Dataset.uid == uid).first()
+    if not dataset:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    return dataset
+
+
+@router.post("", response_model=DatasetResponse, status_code=201)
+def create_dataset(data: DatasetCreate, db: Session = Depends(get_db)):
+    dataset = Dataset(
+        title=data.title,
+        source_ep=data.source_ep,
+        metadata_=data.metadata,
+    )
+    db.add(dataset)
+    db.commit()
+    db.refresh(dataset)
+    return dataset
+
+
+@router.put("/{uid}", response_model=DatasetResponse)
+def update_dataset(uid: UUID, data: DatasetUpdate, db: Session = Depends(get_db)):
+    dataset = db.query(Dataset).filter(Dataset.uid == uid).first()
+    if not dataset:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+
+    update_data = data.model_dump(exclude_unset=True)
+    if "metadata" in update_data:
+        update_data["metadata_"] = update_data.pop("metadata")
+
+    for field, value in update_data.items():
+        setattr(dataset, field, value)
+
+    db.commit()
+    db.refresh(dataset)
+    return dataset
+
+
+@router.delete("/{uid}", status_code=204)
+def delete_dataset(uid: UUID, db: Session = Depends(get_db)):
+    dataset = db.query(Dataset).filter(Dataset.uid == uid).first()
+    if not dataset:
+        raise HTTPException(status_code=404, detail="Dataset not found")
+    db.delete(dataset)
+    db.commit()

--- a/app/routers/service_endpoints.py
+++ b/app/routers/service_endpoints.py
@@ -1,0 +1,52 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.service_endpoint import ServiceEndpoint
+from app.schemas.service_endpoint import ServiceEndpointCreate, ServiceEndpointResponse
+
+router = APIRouter(prefix="/service-endpoints", tags=["service-endpoints"])
+
+
+@router.get("", response_model=list[ServiceEndpointResponse])
+def list_service_endpoints(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(ServiceEndpoint).offset(skip).limit(limit).all()
+
+
+@router.get("/{service_uid}/{endpoint_uid}", response_model=ServiceEndpointResponse)
+def get_service_endpoint(service_uid: UUID, endpoint_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(ServiceEndpoint).filter(
+        ServiceEndpoint.service_uid == service_uid,
+        ServiceEndpoint.endpoint_uid == endpoint_uid
+    ).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="ServiceEndpoint not found")
+    return item
+
+
+@router.post("", response_model=ServiceEndpointResponse, status_code=201)
+def create_service_endpoint(data: ServiceEndpointCreate, db: Session = Depends(get_db)):
+    item = ServiceEndpoint(
+        service_uid=data.service_uid,
+        endpoint_uid=data.endpoint_uid,
+        role=data.role,
+        attrs=data.attrs,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/{service_uid}/{endpoint_uid}", status_code=204)
+def delete_service_endpoint(service_uid: UUID, endpoint_uid: UUID, db: Session = Depends(get_db)):
+    item = db.query(ServiceEndpoint).filter(
+        ServiceEndpoint.service_uid == service_uid,
+        ServiceEndpoint.endpoint_uid == endpoint_uid
+    ).first()
+    if not item:
+        raise HTTPException(status_code=404, detail="ServiceEndpoint not found")
+    db.delete(item)
+    db.commit()

--- a/app/routers/services.py
+++ b/app/routers/services.py
@@ -1,0 +1,65 @@
+from uuid import UUID
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.service import Service
+from app.schemas.service import ServiceCreate, ServiceUpdate, ServiceResponse
+
+router = APIRouter(prefix="/services", tags=["services"])
+
+
+@router.get("", response_model=list[ServiceResponse])
+def list_services(skip: int = 0, limit: int = 100, db: Session = Depends(get_db)):
+    return db.query(Service).offset(skip).limit(limit).all()
+
+
+@router.get("/{uid}", response_model=ServiceResponse)
+def get_service(uid: UUID, db: Session = Depends(get_db)):
+    service = db.query(Service).filter(Service.uid == uid).first()
+    if not service:
+        raise HTTPException(status_code=404, detail="Service not found")
+    return service
+
+
+@router.post("", response_model=ServiceResponse, status_code=201)
+def create_service(data: ServiceCreate, db: Session = Depends(get_db)):
+    service = Service(
+        type=data.type,
+        openapi_url=data.openapi_url,
+        version=data.version,
+        source_ep=data.source_ep,
+        metadata_=data.metadata,
+    )
+    db.add(service)
+    db.commit()
+    db.refresh(service)
+    return service
+
+
+@router.put("/{uid}", response_model=ServiceResponse)
+def update_service(uid: UUID, data: ServiceUpdate, db: Session = Depends(get_db)):
+    service = db.query(Service).filter(Service.uid == uid).first()
+    if not service:
+        raise HTTPException(status_code=404, detail="Service not found")
+
+    update_data = data.model_dump(exclude_unset=True)
+    if "metadata" in update_data:
+        update_data["metadata_"] = update_data.pop("metadata")
+
+    for field, value in update_data.items():
+        setattr(service, field, value)
+
+    db.commit()
+    db.refresh(service)
+    return service
+
+
+@router.delete("/{uid}", status_code=204)
+def delete_service(uid: UUID, db: Session = Depends(get_db)):
+    service = db.query(Service).filter(Service.uid == uid).first()
+    if not service:
+        raise HTTPException(status_code=404, detail="Service not found")
+    db.delete(service)
+    db.commit()

--- a/app/schemas/affinity_triple.py
+++ b/app/schemas/affinity_triple.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class AffinityTripleCreate(BaseModel):
+    dataset_uid: UUID | None = None
+    endpoint_uids: list[UUID] | None = None
+    service_uids: list[UUID] | None = None
+    attrs: dict[str, Any] | None = None
+    version: int | None = None
+
+
+class AffinityTripleUpdate(BaseModel):
+    dataset_uid: UUID | None = None
+    endpoint_uids: list[UUID] | None = None
+    service_uids: list[UUID] | None = None
+    attrs: dict[str, Any] | None = None
+    version: int | None = None
+
+
+class AffinityTripleResponse(BaseModel):
+    triple_uid: UUID
+    dataset_uid: UUID | None = None
+    endpoint_uids: list[UUID] | None = None
+    service_uids: list[UUID] | None = None
+    attrs: dict[str, Any] | None = None
+    version: int | None = None
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/dataset.py
+++ b/app/schemas/dataset.py
@@ -1,0 +1,28 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class DatasetCreate(BaseModel):
+    title: str | None = None
+    source_ep: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class DatasetUpdate(BaseModel):
+    title: str | None = None
+    source_ep: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class DatasetResponse(BaseModel):
+    uid: UUID
+    title: str | None = None
+    source_ep: str | None = None
+    metadata: dict[str, Any] | None = Field(default=None, validation_alias="metadata_")
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/dataset_endpoint.py
+++ b/app/schemas/dataset_endpoint.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DatasetEndpointCreate(BaseModel):
+    dataset_uid: UUID
+    endpoint_uid: UUID
+    role: str | None = None
+    attrs: dict[str, Any] | None = None
+
+
+class DatasetEndpointResponse(BaseModel):
+    dataset_uid: UUID
+    endpoint_uid: UUID
+    role: str | None = None
+    attrs: dict[str, Any] | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/dataset_service.py
+++ b/app/schemas/dataset_service.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class DatasetServiceCreate(BaseModel):
+    dataset_uid: UUID
+    service_uid: UUID
+    role: str | None = None
+    attrs: dict[str, Any] | None = None
+
+
+class DatasetServiceResponse(BaseModel):
+    dataset_uid: UUID
+    service_uid: UUID
+    role: str | None = None
+    attrs: dict[str, Any] | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/service.py
+++ b/app/schemas/service.py
@@ -1,0 +1,34 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field
+
+
+class ServiceCreate(BaseModel):
+    type: str | None = None
+    openapi_url: str | None = None
+    version: str | None = None
+    source_ep: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class ServiceUpdate(BaseModel):
+    type: str | None = None
+    openapi_url: str | None = None
+    version: str | None = None
+    source_ep: str | None = None
+    metadata: dict[str, Any] | None = None
+
+
+class ServiceResponse(BaseModel):
+    uid: UUID
+    type: str | None = None
+    openapi_url: str | None = None
+    version: str | None = None
+    source_ep: str | None = None
+    metadata: dict[str, Any] | None = Field(default=None, validation_alias="metadata_")
+    created_at: datetime
+    updated_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)

--- a/app/schemas/service_endpoint.py
+++ b/app/schemas/service_endpoint.py
@@ -1,0 +1,22 @@
+from datetime import datetime
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict
+
+
+class ServiceEndpointCreate(BaseModel):
+    service_uid: UUID
+    endpoint_uid: UUID
+    role: str | None = None
+    attrs: dict[str, Any] | None = None
+
+
+class ServiceEndpointResponse(BaseModel):
+    service_uid: UUID
+    endpoint_uid: UUID
+    role: str | None = None
+    attrs: dict[str, Any] | None = None
+    created_at: datetime
+
+    model_config = ConfigDict(from_attributes=True)


### PR DESCRIPTION
## Summary
Add FastAPI CRUD endpoints for all remaining tables:

- `/datasets` - Dataset management
- `/services` - Service management  
- `/dataset-endpoints` - Dataset-Endpoint relationships
- `/dataset-services` - Dataset-Service relationships
- `/service-endpoints` - Service-Endpoint relationships
- `/affinities` - Affinity triples

## Endpoints added
| Resource | Routes |
|----------|--------|
| Datasets | GET, GET/:uid, POST, PUT/:uid, DELETE/:uid |
| Services | GET, GET/:uid, POST, PUT/:uid, DELETE/:uid |
| Dataset-Endpoints | GET, GET/:d/:e, POST, DELETE/:d/:e |
| Dataset-Services | GET, GET/:d/:s, POST, DELETE/:d/:s |
| Service-Endpoints | GET, GET/:s/:e, POST, DELETE/:s/:e |
| Affinities | GET, GET/:uid, POST, PUT/:uid, DELETE/:uid |

Closes #23