### PR TITLE
Add production configuration and update documentation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,12 +1,21 @@
+# PostgreSQL
 POSTGRES_USER=affinities
 POSTGRES_PASSWORD=affinities
 POSTGRES_DB=affinities
 POSTGRES_PORT=5432
 
+# pgAdmin (development only)
 PGADMIN_EMAIL=admin@admin.com
 PGADMIN_PASSWORD=admin
 PGADMIN_PORT=5050
 
-# FastAPI
+# API
 DATABASE_URL=postgresql://affinities:affinities@localhost:5432/affinities
 API_PORT=8000
+# CORS origins (comma-separated for multiple, or "*" for all)
+CORS_ORIGINS=*
+
+# Frontend
+FRONTEND_PORT=3000
+# API URL for frontend (used at build time)
+VITE_API_URL=http://localhost:8000

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # NDP Affinities
 
-PostgreSQL database for the NDP Affinities system.
+PostgreSQL database with FastAPI backend and React frontend for the NDP Affinities system.
 
 ## Requirements
 
@@ -17,6 +17,7 @@ This will start:
 - **PostgreSQL** on `localhost:5432`
 - **pgAdmin** on `http://localhost:5050`
 - **API** on `http://localhost:8000` (Swagger UI at `/docs`)
+- **Frontend** on `http://localhost:3000`
 
 Migrations run automatically on first startup.
 
@@ -51,13 +52,50 @@ cp .env.example .env
 |----------|---------|-------------|
 | `DATABASE_URL` | `postgresql://affinities:affinities@localhost:5432/affinities` | Database connection string |
 | `API_PORT` | `8000` | Exposed port |
+| `CORS_ORIGINS` | `*` | Allowed CORS origins (comma-separated, or `*` for all) |
+
+### Frontend
+
+| Variable | Default | Description |
+|----------|---------|-------------|
+| `FRONTEND_PORT` | `3000` | Exposed port |
+| `VITE_API_URL` | `http://localhost:8000` | API URL (used at build time) |
+
+## Production Deployment
+
+For production, use `docker-compose.prod.yml` which excludes pgAdmin and requires explicit configuration:
+
+```bash
+# Create .env with production values (change passwords!)
+cp .env.example .env
+# Edit .env with secure passwords and proper CORS_ORIGINS
+
+# Start production services
+docker compose -f docker-compose.prod.yml up -d
+```
+
+Production configuration notes:
+- Set strong passwords for `POSTGRES_USER` and `POSTGRES_PASSWORD`
+- Set `CORS_ORIGINS` to your frontend domain (e.g., `https://yourdomain.com`)
+- Set `VITE_API_URL` to your API URL (e.g., `https://api.yourdomain.com`)
+- Configure a reverse proxy (nginx, traefik) for HTTPS
 
 ## Local Development
+
+### API
 
 ```bash
 python3 -m venv .venv
 .venv/bin/pip install -r requirements.txt
 .venv/bin/uvicorn app.main:app --reload
+```
+
+### Frontend
+
+```bash
+cd frontend
+npm install
+npm run dev
 ```
 
 ## Running Tests
@@ -78,8 +116,11 @@ python3 -m venv .venv
 ## Commands
 
 ```bash
-# Start services
+# Start services (development)
 docker compose up -d
+
+# Start services (production)
+docker compose -f docker-compose.prod.yml up -d
 
 # Stop services
 docker compose down
@@ -193,11 +234,12 @@ Stores affinity combinations (dataset + endpoints + services).
 
 ```
 .
-├── docker-compose.yml
-├── Dockerfile
+├── docker-compose.yml        # Development setup
+├── docker-compose.prod.yml   # Production setup (no pgAdmin)
+├── Dockerfile                # API container
 ├── requirements.txt
 ├── .env.example
-├── app/                  # FastAPI application
+├── app/                      # FastAPI application
 │   ├── main.py
 │   ├── config.py
 │   ├── database.py
@@ -205,7 +247,16 @@ Stores affinity combinations (dataset + endpoints + services).
 │   ├── models/
 │   ├── schemas/
 │   └── routers/
-├── tests/                # Test suite
+├── frontend/                 # React frontend
+│   ├── Dockerfile
+│   ├── nginx.conf
+│   ├── src/
+│   │   ├── api/
+│   │   ├── components/
+│   │   ├── pages/
+│   │   └── types/
+│   └── ...
+├── tests/                    # Test suite
 ├── pgadmin/
 │   └── servers.json
 └── sql/

--- a/app/config.py
+++ b/app/config.py
@@ -3,9 +3,15 @@ from pydantic_settings import BaseSettings
 
 class Settings(BaseSettings):
     database_url: str = "postgresql://affinities:affinities@localhost:5432/affinities"
+    cors_origins: str = "*"
 
     class Config:
         env_file = ".env"
+
+    def get_cors_origins(self) -> list[str]:
+        if self.cors_origins == "*":
+            return ["*"]
+        return [origin.strip() for origin in self.cors_origins.split(",")]
 
 
 settings = Settings()

--- a/app/main.py
+++ b/app/main.py
@@ -5,6 +5,7 @@ from fastapi.middleware.cors import CORSMiddleware
 from fastapi.responses import JSONResponse
 from sqlalchemy.exc import IntegrityError
 
+from app.config import settings
 from app.routers import (
     endpoints_router,
     datasets_router,
@@ -23,7 +24,7 @@ app = FastAPI(
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=["*"],
+    allow_origins=settings.get_cors_origins(),
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,0 +1,39 @@
+services:
+  postgres:
+    image: postgres:16-alpine
+    container_name: ndp-affinities-db
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
+      POSTGRES_DB: ${POSTGRES_DB}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+      - ./sql/migrations:/docker-entrypoint-initdb.d:ro
+    restart: unless-stopped
+
+  api:
+    build: .
+    container_name: ndp-affinities-api
+    environment:
+      DATABASE_URL: postgresql://${POSTGRES_USER}:${POSTGRES_PASSWORD}@postgres:5432/${POSTGRES_DB}
+      CORS_ORIGINS: ${CORS_ORIGINS}
+    ports:
+      - "${API_PORT:-8000}:8000"
+    depends_on:
+      - postgres
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: ./frontend
+      args:
+        VITE_API_URL: ${VITE_API_URL}
+    container_name: ndp-affinities-frontend
+    ports:
+      - "${FRONTEND_PORT:-3000}:80"
+    depends_on:
+      - api
+    restart: unless-stopped
+
+volumes:
+  postgres_data:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,6 +2,9 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
+ARG VITE_API_URL=http://localhost:8000
+ENV VITE_API_URL=${VITE_API_URL}
+
 COPY package*.json ./
 RUN npm ci
 


### PR DESCRIPTION
## Summary
- Make CORS origins configurable via `CORS_ORIGINS` environment variable
- Add `docker-compose.prod.yml` for production deployment (without pgAdmin)
- Update frontend Dockerfile to accept `VITE_API_URL` build argument
- Update README with frontend documentation
- Add production deployment section to README
- Update `.env.example` with all new variables (`CORS_ORIGINS`, `FRONTEND_PORT`, `VITE_API_URL`)
- Update project structure in README

## Test plan
- Run tests: `pytest` (all 64 tests pass)
- Verify `docker compose up` still works
- Verify `docker compose -f docker-compose.prod.yml up` works

Closes #35