### PR TITLE
Add API tutorial Jupyter Notebook (v0.1.1)

### DIFF
--- a/docs/api_tutorial_v0.1.1.ipynb
+++ b/docs/api_tutorial_v0.1.1.ipynb
@@ -1,0 +1,524 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# NDP Affinities API Tutorial\n",
+    "\n",
+    "**API Version: 0.1.1**\n",
+    "\n",
+    "This notebook demonstrates how to use all endpoints of the NDP Affinities API.\n",
+    "\n",
+    "## Setup\n",
+    "\n",
+    "First, let's set up our base URL and import the required libraries."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import requests\n",
+    "import json\n",
+    "\n",
+    "# Change this to your API URL\n",
+    "BASE_URL = \"http://localhost:8000\"\n",
+    "\n",
+    "def pretty_print(data):\n",
+    "    \"\"\"Pretty print JSON data\"\"\"\n",
+    "    print(json.dumps(data, indent=2))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1. Health Check\n",
+    "\n",
+    "Verify the API is running."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/health\")\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2. Endpoints (`/ep`)\n",
+    "\n",
+    "Manage data endpoints (e.g., CKAN instances, APIs, data sources).\n",
+    "\n",
+    "### 2.1 Create an Endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "endpoint_data = {\n",
+    "    \"kind\": \"ckan\",\n",
+    "    \"url\": \"https://demo.ckan.org\",\n",
+    "    \"metadata\": {\n",
+    "        \"name\": \"CKAN Demo\",\n",
+    "        \"description\": \"Official CKAN demonstration site\"\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/ep\", json=endpoint_data)\n",
+    "endpoint = response.json()\n",
+    "pretty_print(endpoint)\n",
+    "\n",
+    "# Save the UID for later use\n",
+    "endpoint_uid = endpoint[\"uid\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.2 List All Endpoints"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/ep\")\n",
+    "endpoints = response.json()\n",
+    "print(f\"Total endpoints: {len(endpoints)}\")\n",
+    "pretty_print(endpoints[:2])  # Show first 2"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.3 Get a Specific Endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/ep/{endpoint_uid}\")\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.4 Update an Endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "update_data = {\n",
+    "    \"metadata\": {\n",
+    "        \"name\": \"CKAN Demo (Updated)\",\n",
+    "        \"description\": \"Official CKAN demonstration site\",\n",
+    "        \"updated\": True\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "response = requests.patch(f\"{BASE_URL}/ep/{endpoint_uid}\", json=update_data)\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2.5 Delete an Endpoint"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.delete(f\"{BASE_URL}/ep/{endpoint_uid}\")\n",
+    "print(f\"Status: {response.status_code}\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 3. Datasets (`/datasets`)\n",
+    "\n",
+    "Manage dataset records.\n",
+    "\n",
+    "### 3.1 Create a Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "dataset_data = {\n",
+    "    \"title\": \"Climate Data 2024\",\n",
+    "    \"metadata\": {\n",
+    "        \"description\": \"Global climate measurements\",\n",
+    "        \"format\": \"CSV\",\n",
+    "        \"size\": \"1.2GB\"\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/datasets\", json=dataset_data)\n",
+    "dataset = response.json()\n",
+    "pretty_print(dataset)\n",
+    "\n",
+    "dataset_uid = dataset[\"uid\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.2 List All Datasets"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/datasets\")\n",
+    "datasets = response.json()\n",
+    "print(f\"Total datasets: {len(datasets)}\")\n",
+    "pretty_print(datasets[:2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 3.3 Get a Specific Dataset"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/datasets/{dataset_uid}\")\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 4. Services (`/services`)\n",
+    "\n",
+    "Manage service records (APIs, processing services, etc.).\n",
+    "\n",
+    "### 4.1 Create a Service"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "service_data = {\n",
+    "    \"type\": \"processing\",\n",
+    "    \"openapi_url\": \"https://api.example.com/openapi.json\",\n",
+    "    \"version\": \"1.0.0\",\n",
+    "    \"metadata\": {\n",
+    "        \"name\": \"Data Processing Service\",\n",
+    "        \"description\": \"Transforms and aggregates data\"\n",
+    "    }\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/services\", json=service_data)\n",
+    "service = response.json()\n",
+    "pretty_print(service)\n",
+    "\n",
+    "service_uid = service[\"uid\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 4.2 List All Services"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/services\")\n",
+    "services = response.json()\n",
+    "print(f\"Total services: {len(services)}\")\n",
+    "pretty_print(services[:2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 5. Relationships\n",
+    "\n",
+    "Connect datasets with endpoints and services.\n",
+    "\n",
+    "### 5.1 Link Dataset to Endpoint (`/dataset-endpoints`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# First, create a new endpoint for this example\n",
+    "ep_response = requests.post(f\"{BASE_URL}/ep\", json={\"kind\": \"api\", \"url\": \"https://api.example.com\"})\n",
+    "new_endpoint_uid = ep_response.json()[\"uid\"]\n",
+    "\n",
+    "# Link dataset to endpoint\n",
+    "link_data = {\n",
+    "    \"dataset_uid\": dataset_uid,\n",
+    "    \"endpoint_uid\": new_endpoint_uid,\n",
+    "    \"role\": \"source\",\n",
+    "    \"attrs\": {\"priority\": 1}\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/dataset-endpoints\", json=link_data)\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.2 Link Dataset to Service (`/dataset-services`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "link_data = {\n",
+    "    \"dataset_uid\": dataset_uid,\n",
+    "    \"service_uid\": service_uid,\n",
+    "    \"role\": \"processor\",\n",
+    "    \"attrs\": {\"schedule\": \"daily\"}\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/dataset-services\", json=link_data)\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 5.3 Link Service to Endpoint (`/service-endpoints`)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "link_data = {\n",
+    "    \"service_uid\": service_uid,\n",
+    "    \"endpoint_uid\": new_endpoint_uid,\n",
+    "    \"role\": \"provider\"\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/service-endpoints\", json=link_data)\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 6. Affinities (`/affinities`)\n",
+    "\n",
+    "Create affinity triples (dataset + endpoints + services combinations).\n",
+    "\n",
+    "### 6.1 Create an Affinity"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "affinity_data = {\n",
+    "    \"dataset_uid\": dataset_uid,\n",
+    "    \"endpoint_uids\": [new_endpoint_uid],\n",
+    "    \"service_uids\": [service_uid],\n",
+    "    \"attrs\": {\"confidence\": 0.95}\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/affinities\", json=affinity_data)\n",
+    "affinity = response.json()\n",
+    "pretty_print(affinity)\n",
+    "\n",
+    "affinity_uid = affinity[\"triple_uid\"]"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 6.2 List All Affinities"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/affinities\")\n",
+    "affinities = response.json()\n",
+    "print(f\"Total affinities: {len(affinities)}\")\n",
+    "pretty_print(affinities[:2])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 7. Linked Entities (`/linked`)\n",
+    "\n",
+    "Query related entities for a given UID.\n",
+    "\n",
+    "### 7.1 Get Linked Entities for a Single UID"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "response = requests.get(f\"{BASE_URL}/linked/{dataset_uid}\")\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 7.2 Batch Query for Multiple UIDs"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "batch_data = {\n",
+    "    \"uids\": [dataset_uid, service_uid]\n",
+    "}\n",
+    "\n",
+    "response = requests.post(f\"{BASE_URL}/linked/batch\", json=batch_data)\n",
+    "pretty_print(response.json())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 8. Cleanup\n",
+    "\n",
+    "Delete the resources created in this tutorial."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Delete in reverse order of dependencies\n",
+    "requests.delete(f\"{BASE_URL}/affinities/{affinity_uid}\")\n",
+    "requests.delete(f\"{BASE_URL}/dataset-endpoints/{dataset_uid}/{new_endpoint_uid}\")\n",
+    "requests.delete(f\"{BASE_URL}/dataset-services/{dataset_uid}/{service_uid}\")\n",
+    "requests.delete(f\"{BASE_URL}/service-endpoints/{service_uid}/{new_endpoint_uid}\")\n",
+    "requests.delete(f\"{BASE_URL}/datasets/{dataset_uid}\")\n",
+    "requests.delete(f\"{BASE_URL}/services/{service_uid}\")\n",
+    "requests.delete(f\"{BASE_URL}/ep/{new_endpoint_uid}\")\n",
+    "\n",
+    "print(\"Cleanup complete!\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This tutorial covered all main endpoints of the NDP Affinities API:\n",
+    "\n",
+    "| Endpoint | Description |\n",
+    "|----------|-------------|\n",
+    "| `/health` | Health check |\n",
+    "| `/ep` | Manage endpoints |\n",
+    "| `/datasets` | Manage datasets |\n",
+    "| `/services` | Manage services |\n",
+    "| `/dataset-endpoints` | Link datasets to endpoints |\n",
+    "| `/dataset-services` | Link datasets to services |\n",
+    "| `/service-endpoints` | Link services to endpoints |\n",
+    "| `/affinities` | Manage affinity triples |\n",
+    "| `/linked` | Query related entities |\n",
+    "\n",
+    "For more details, visit the Swagger UI at `/docs`."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "name": "python",
+   "version": "3.12.0"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}


### PR DESCRIPTION
## Summary
Add comprehensive API tutorial as Jupyter Notebook.

## Contents
- Health check
- Endpoints CRUD
- Datasets CRUD
- Services CRUD
- Relationships (dataset-endpoints, dataset-services, service-endpoints)
- Affinities
- Linked entities queries

## Notes
- Notebook name includes API version for tracking
- Includes cleanup section

Closes #47