### PR TITLE
Switch frontend to runtime environment variables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,14 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-04-08
+
+### Changed
+- Switch frontend from build-time to runtime environment variables
+- Add entrypoint.sh that generates config.js and dynamic nginx config at container startup
+- Frontend now reads ROOT_PATH and VITE_API_URL at runtime via window.__AFFINITIES_CONFIG__
+- Docker Compose passes environment variables instead of build args
+
 ### Added
 - API tutorial Jupyter Notebook (docs/api_tutorial_v0.1.1.ipynb)
 
@@ -37,7 +45,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pagination support in dashboard
 - CKAN names display in listings
 
-[Unreleased]: https://github.com/sci-ndp/ndp-affinities/compare/v0.1.1...HEAD
+[Unreleased]: https://github.com/sci-ndp/ndp-affinities/compare/v0.2.0...HEAD
+[0.2.0]: https://github.com/sci-ndp/ndp-affinities/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/sci-ndp/ndp-affinities/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/sci-ndp/ndp-affinities/compare/v0.0.0...v0.1.0
 [0.0.0]: https://github.com/sci-ndp/ndp-affinities/releases/tag/v0.0.0

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ from app.routers import (
 app = FastAPI(
     title="NDP Affinities API",
     description="API for managing NDP affinities data",
-    version="0.1.1",
+    version="0.2.0",
     root_path="/affinity-api",
 )
 app.add_middleware(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,10 +43,10 @@ services:
   frontend:
     build:
       context: ./frontend
-      args:
-        VITE_API_URL: ${VITE_API_URL:-http://localhost:8000}
-        VITE_BASE_PATH: ${VITE_BASE_PATH:-/}
     container_name: ndp-affinities-frontend
+    environment:
+      ROOT_PATH: ${ROOT_PATH:-/}
+      VITE_API_URL: ${VITE_API_URL:-http://localhost:8000}
     ports:
       - "${FRONTEND_PORT:-3000}:80"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -2,11 +2,6 @@ FROM node:20-alpine AS builder
 
 WORKDIR /app
 
-ARG VITE_API_URL=http://localhost:8000
-ENV VITE_API_URL=${VITE_API_URL}
-ARG VITE_BASE_PATH=/
-ENV VITE_BASE_PATH=${VITE_BASE_PATH}
-
 COPY package*.json ./
 RUN npm ci
 
@@ -16,8 +11,9 @@ RUN npm run build
 FROM nginx:alpine
 
 COPY --from=builder /app/dist /usr/share/nginx/html
-COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
 
 EXPOSE 80
 
-CMD ["nginx", "-g", "daemon off;"]
+CMD ["/entrypoint.sh"]

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -54,15 +54,15 @@ server {
     location ${LOCATION_PATH}/ {
         alias /usr/share/nginx/html/;
         try_files \$uri \$uri/ ${LOCATION_PATH}/index.html;
+
+        location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+            expires 1y;
+            add_header Cache-Control "public, immutable";
+        }
     }
 
     location = ${LOCATION_PATH} {
         return 301 \$scheme://\$host${LOCATION_PATH}/;
-    }
-
-    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
-        expires 1y;
-        add_header Cache-Control "public, immutable";
     }
 }
 NGINX

--- a/frontend/entrypoint.sh
+++ b/frontend/entrypoint.sh
@@ -1,0 +1,72 @@
+#!/bin/sh
+
+ROOT_PATH="${ROOT_PATH:-/}"
+VITE_API_URL="${VITE_API_URL:-http://localhost:8000}"
+
+# Ensure ROOT_PATH ends with /
+case "$ROOT_PATH" in
+  */) ;;
+  *)  ROOT_PATH="${ROOT_PATH}/" ;;
+esac
+
+# Generate runtime config for the React app
+cat > /usr/share/nginx/html/config.js <<EOF
+window.__AFFINITIES_CONFIG__ = {
+  rootPath: "${ROOT_PATH}",
+  apiUrl: "${VITE_API_URL}"
+};
+EOF
+
+# Rewrite asset paths in index.html to include ROOT_PATH prefix (only if not /)
+if [ "$ROOT_PATH" != "/" ]; then
+  sed -i "s|=\"/assets/|=\"${ROOT_PATH}assets/|g" /usr/share/nginx/html/index.html
+  sed -i "s|=\"/config.js\"|=\"${ROOT_PATH}config.js\"|g" /usr/share/nginx/html/index.html
+fi
+
+# Generate nginx config dynamically
+if [ "$ROOT_PATH" = "/" ]; then
+  cat > /etc/nginx/conf.d/default.conf <<NGINX
+server {
+    listen 80;
+    server_name localhost;
+    root /usr/share/nginx/html;
+    index index.html;
+
+    location / {
+        try_files \$uri \$uri/ /index.html;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}
+NGINX
+else
+  # Strip trailing slash for location block
+  LOCATION_PATH=$(echo "$ROOT_PATH" | sed 's|/$||')
+
+  cat > /etc/nginx/conf.d/default.conf <<NGINX
+server {
+    listen 80;
+    server_name localhost;
+
+    location ${LOCATION_PATH}/ {
+        alias /usr/share/nginx/html/;
+        try_files \$uri \$uri/ ${LOCATION_PATH}/index.html;
+    }
+
+    location = ${LOCATION_PATH} {
+        return 301 \$scheme://\$host${LOCATION_PATH}/;
+    }
+
+    location ~* \.(js|css|png|jpg|jpeg|gif|ico|svg)$ {
+        expires 1y;
+        add_header Cache-Control "public, immutable";
+    }
+}
+NGINX
+fi
+
+# Start nginx
+exec nginx -g 'daemon off;'

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,6 +4,7 @@
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>NDP Affinities</title>
+    <script src="/config.js"></script>
   </head>
   <body>
     <div id="root"></div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -15,8 +15,8 @@ import {
 import './App.css';
 
 function App() {
-  const baseUrl = import.meta.env.BASE_URL || '/';
-  const basename = baseUrl === '/' ? undefined : baseUrl.replace(/\/$/, '');
+  const basePath = (window as any).__AFFINITIES_CONFIG__?.rootPath ?? '/';
+  const basename = basePath === '/' ? undefined : basePath.replace(/\/$/, '');
 
   return (
     <BrowserRouter basename={basename}>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -9,7 +9,7 @@ import type {
   Affinity, AffinityCreate, AffinityUpdate
 } from '../types';
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000';
+const API_BASE_URL = (window as any).__AFFINITIES_CONFIG__?.apiUrl || 'http://localhost:8000';
 
 const api = axios.create({
   baseURL: API_BASE_URL,

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -1,14 +1,9 @@
-import { defineConfig, loadEnv } from 'vite'
+import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 // https://vite.dev/config/
-export default defineConfig(({ mode }) => {
-  const env = loadEnv(mode, process.cwd(), '')
-  const basePath = env.VITE_BASE_PATH || '/'
-  const normalizedBase = basePath.endsWith('/') ? basePath : `${basePath}/`
-
-  return {
-    plugins: [react()],
-    base: normalizedBase,
-  }
+// Base path is injected at runtime via entrypoint.sh, so we always build with '/'
+export default defineConfig({
+  plugins: [react()],
+  base: '/',
 })


### PR DESCRIPTION
## Summary
- Replace build-time `VITE_BASE_PATH` and `VITE_API_URL` with runtime configuration, matching the pattern used by ep-api and federation
- Add `entrypoint.sh` that generates `config.js` (with `window.__AFFINITIES_CONFIG__`) and dynamic nginx config at container startup
- Frontend reads `ROOT_PATH` and `VITE_API_URL` from environment at runtime — no rebuild needed to change paths
- Docker Compose now passes these as `environment` variables instead of `build args`

## Changes
- **New**: `frontend/entrypoint.sh` — runtime config generator + nginx configurator
- **Modified**: `frontend/index.html` — loads `config.js` in `<head>`
- **Modified**: `frontend/src/App.tsx` — reads `rootPath` from `window.__AFFINITIES_CONFIG__`
- **Modified**: `frontend/src/api/client.ts` — reads `apiUrl` from `window.__AFFINITIES_CONFIG__`
- **Modified**: `frontend/vite.config.ts` — always builds with `base: '/'`
- **Modified**: `frontend/Dockerfile` — uses `entrypoint.sh` as CMD, no build args
- **Modified**: `docker-compose.yml` — runtime `environment` instead of build `args`
- **Bumped**: version to 0.2.0

## Test plan
- [x] `docker compose up -d --build frontend` builds successfully
- [x] `http://localhost:3000/affinities/` returns 200
- [x] `config.js` is generated with correct values
- [x] Static assets (JS, CSS) load correctly under subpath
- [x] SPA routes (e.g. `/affinities/endpoints`) return 200
- [x] `/affinities` redirects to `/affinities/`
- [x] nginx-proxy passes requests correctly without stripping the path

Closes #51