### PR TITLE
feat(api): make root path configurable via ROOT_PATH (v0.3.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-07-09
+
+### Changed
+- API root path is now read from the `ROOT_PATH` environment variable instead of being hardcoded to `/affinity-api`, so the same image can be served under any prefix behind a reverse proxy (defaults to no prefix)
+- Docker Compose passes `ROOT_PATH` through to the API service
+
 ## [0.2.0] - 2026-04-08
 
 ### Changed
@@ -45,7 +51,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Pagination support in dashboard
 - CKAN names display in listings
 
-[Unreleased]: https://github.com/sci-ndp/ndp-affinities/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/sci-ndp/ndp-affinities/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/sci-ndp/ndp-affinities/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/sci-ndp/ndp-affinities/compare/v0.1.1...v0.2.0
 [0.1.1]: https://github.com/sci-ndp/ndp-affinities/compare/v0.1.0...v0.1.1
 [0.1.0]: https://github.com/sci-ndp/ndp-affinities/compare/v0.0.0...v0.1.0

--- a/app/config.py
+++ b/app/config.py
@@ -4,6 +4,7 @@ from pydantic_settings import BaseSettings
 class Settings(BaseSettings):
     database_url: str = "postgresql://affinities:affinities@localhost:5432/affinities"
     cors_origins: str = "*"
+    root_path: str = ""
 
     class Config:
         env_file = ".env"

--- a/app/main.py
+++ b/app/main.py
@@ -21,7 +21,7 @@ app = FastAPI(
     title="NDP Affinities API",
     description="API for managing NDP affinities data",
     version="0.2.0",
-    root_path="/affinity-api",
+    root_path=settings.root_path,
 )
 app.add_middleware(
     CORSMiddleware,

--- a/app/main.py
+++ b/app/main.py
@@ -20,7 +20,7 @@ from app.routers import (
 app = FastAPI(
     title="NDP Affinities API",
     description="API for managing NDP affinities data",
-    version="0.2.0",
+    version="0.3.0",
     root_path=settings.root_path,
 )
 app.add_middleware(

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -34,6 +34,7 @@ services:
     environment:
       DATABASE_URL: postgresql://${POSTGRES_USER:-affinities}:${POSTGRES_PASSWORD:-affinities}@postgres:5432/${POSTGRES_DB:-affinities}
       CORS_ORIGINS: ${CORS_ORIGINS:-*}
+      ROOT_PATH: ${ROOT_PATH:-}
     ports:
       - "${API_PORT:-8000}:8000"
     depends_on:


### PR DESCRIPTION
## Summary

The FastAPI application hardcoded `root_path="/affinity-api"`, so the published image could not be served under any other prefix without a rebuild. A deployment exposing the API behind a reverse proxy at a different prefix (e.g. `/affinities-api/`) ended up with broken Swagger docs and incorrect generated URLs.

## Changes

- `app/config.py`: new `root_path` setting (defaults to an empty string).
- `app/main.py`: `root_path` is read from settings instead of the hardcoded literal.
- `docker-compose.yml`: passes `ROOT_PATH` through to the API service.

The frontend already resolved `ROOT_PATH` at runtime, so this brings the API in line: one image, any prefix.

## Testing

Full suite passes locally: `69 passed`.

## Release

Version bumped to 0.3.0 (`app/main.py`, `CHANGELOG.md`).